### PR TITLE
install dev package only for actual cluster version

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -73,7 +73,7 @@ action :create do
   end
 
   # Install postgresql server packages
-  %W(postgresql-#{cluster_version} postgresql-server-dev-all).each do |pkg|
+  %W(postgresql-#{cluster_version} postgresql-server-dev-#{cluster_version}).each do |pkg|
     package pkg
   end
 


### PR DESCRIPTION
I suggest that we need to use only current cluster version of dev package, it's useful where we use for e.g. pgxn or working with pg extensions at all on machine which using latest pg dev version by default for installing extensions.

I know it's not panacea where you have several pg clusters on same machine, but currently main idea in current pr.