### PR TITLE
CloudBackup: add prefix to crontab command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ postgresql_database 'database01' do
 end
 ```
 
+Example full daily database backup
+
+```ruby
+postgresql_cloud_backup 'main' do
+  in_version '9.3'
+  in_cluster 'main'
+  full_backup_time weekday: '*', month: '*', day: '*', hour: '3', minute: '0'
+  # Data bag item should contain following keys for S3 protocol:
+  # aws_access_key_id, aws_secret_access_key, wale_s3_prefix
+  params Chef::EncryptedDataBagItem.load('s3', 'secrets').to_hash.select {|i| i != "id"}
+  # Or just a hash, if you don't use data bags:
+  params { aws_access_key_id: 'access_key', aws_secret_access_key: 'secret_key', wale_s3_prefix: 's3_prefix' }
+  protocol 's3'
+  # In case you need to prepend wal-e with, for example, traffic limiter
+  # you can use following method:
+  command_prefix 'trickle -s -u 1024'
+  # It will be prepended to resulting wal-e execution in cron task
+end
+```
+
 License and Author
 ==================
 

--- a/libraries/resource_postgresql_cloud_backup.rb
+++ b/libraries/resource_postgresql_cloud_backup.rb
@@ -36,6 +36,12 @@ class Chef
         set_or_return(:credentials, arg, kind_of: Hash, required: true)
       end
 
+      # Crontab command prefix to use with wal-e
+      # e.g. for speed limit by trickle like `trickle -s -u 1024 envdir /etc/wal-e.d/...`
+      def command_prefix(arg = '')
+        set_or_return(:command_prefix, arg, kind_of: String, required: false)
+      end
+
       def full_backup_time(arg = nil)
         set_or_return(:full_backup_time, arg, kind_of: Hash, default: { minute: '0', hour: '3', day: '*', month: '*', weekday: '*' })
       end

--- a/providers/cloud_backup.rb
+++ b/providers/cloud_backup.rb
@@ -35,7 +35,8 @@ action :schedule do
   postgresql_instance_name = new_resource.in_cluster
   postgresql_name_version  = "#{postgresql_instance_name}-#{postgresql_version}"
   postgresql_path          = "/var/lib/postgresql/#{postgresql_version}/#{postgresql_instance_name}"
-  wal_e_bin               = node['postgresql']['cloud_backup']['wal_e_bin']
+  wal_e_bin                = node['postgresql']['cloud_backup']['wal_e_bin']
+  command_prefix           = new_resource.command_prefix
   envdir_params            = new_resource.params
   full_backup_time         = new_resource.full_backup_time
 
@@ -84,7 +85,7 @@ action :schedule do
 
   # Create crontask via cron cookbook
   cron_d "backup_postgresql_cluster_#{postgresql_name_version.sub('.', '-')}" do
-    command "envdir /etc/wal-e.d/#{postgresql_name_version}/env #{wal_e_bin} backup-push #{postgresql_path}"
+    command "#{command_prefix} envdir /etc/wal-e.d/#{postgresql_name_version}/env #{wal_e_bin} backup-push #{postgresql_path}"
     user 'postgres'
     minute full_backup_time[:minute]
     hour full_backup_time[:hour]


### PR DESCRIPTION
Add crontab command prefix to use with `wal-e`
e.g. for speed limit by trickle like `trickle -s -u 1024 envdir /etc/wal-e.d/...`
