### PR TITLE
Libraries::ResourcePostgresqlCloudBackup: default argument value should ...

### DIFF
--- a/libraries/resource_postgresql_cloud_backup.rb
+++ b/libraries/resource_postgresql_cloud_backup.rb
@@ -39,7 +39,7 @@ class Chef
       # Crontab command prefix to use with wal-e
       # e.g. for speed limit by trickle like `trickle -s -u 1024 envdir /etc/wal-e.d/...`
       def command_prefix(arg = nil)
-        set_or_return(:command_prefix, arg, kind_of: String, required: true)
+        set_or_return(:command_prefix, arg, kind_of: String, required: false)
       end
 
       def full_backup_time(arg = nil)

--- a/libraries/resource_postgresql_cloud_backup.rb
+++ b/libraries/resource_postgresql_cloud_backup.rb
@@ -38,8 +38,8 @@ class Chef
 
       # Crontab command prefix to use with wal-e
       # e.g. for speed limit by trickle like `trickle -s -u 1024 envdir /etc/wal-e.d/...`
-      def command_prefix(arg = '')
-        set_or_return(:command_prefix, arg, kind_of: String, required: false)
+      def command_prefix(arg = nil)
+        set_or_return(:command_prefix, arg, kind_of: String, required: true)
       end
 
       def full_backup_time(arg = nil)


### PR DESCRIPTION
...be nil because of `set_or_return` behaviour:

      if arg == nil && self.instance_variable_defined?(iv_symbol) == true

In this way, assigned value will be returned only if default value will be `nil`